### PR TITLE
Linking fixes

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -1,6 +1,10 @@
 # Class: hadoop::setup
 #
 class hadoop::setup {
+  file {'/usr/libexec':
+      ensure => directory
+  }
+
   File {
     purge   => true,
     force   => true,

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -19,7 +19,7 @@ class hadoop::setup {
 
     # etc
     '/etc/hadoop':
-      target => "${hadoop::install_dir}/etc";
+      target => "${hadoop::install_dir}/etc/hadoop";
 
     # share
     '/usr/share/hadoop':


### PR DESCRIPTION
The puppet setup puppet file linked `$PUPPET_HOME/etc/hadoop` to `/etc/hadoop/hadoop`, instead of the correct `/etc/hadoop`. Also, on Ubuntu 16.04, the `/usr/libexec` directory does not exist. Added a check to ensure that it does.
